### PR TITLE
Fix dependencies

### DIFF
--- a/crispy/quanty/__init__.py
+++ b/crispy/quanty/__init__.py
@@ -11,7 +11,7 @@
 import os
 
 import xraydb
-import yaml
+from ruamel import yaml
 
 from crispy import resourceAbsolutePath
 
@@ -19,4 +19,4 @@ XDB = xraydb.XrayDB()
 
 path = os.path.join("quanty", "calculations.yaml")
 with open(resourceAbsolutePath(path), encoding="utf-8") as fp:
-    CALCULATIONS = yaml.load(fp, Loader=yaml.FullLoader)
+    CALCULATIONS = yaml.load(fp, Loader=yaml.Loader)

--- a/crispy/quanty/templates/tests/test_templates.py
+++ b/crispy/quanty/templates/tests/test_templates.py
@@ -15,7 +15,7 @@ import os
 
 import numpy as np
 import pytest
-import yaml
+from ruamel import yaml
 
 from crispy.config import Config
 from crispy.notebook import calculation
@@ -24,7 +24,7 @@ from crispy.notebook import calculation
 def get_test_data():
     path = os.path.join(os.path.dirname(__file__), "test_data.yaml")
     with open(path, encoding="utf-8") as f:
-        yield from list(yaml.load(f, Loader=yaml.FullLoader).items())
+        yield from list(yaml.load(f, Loader=yaml.Loader).items())
 
 
 def set_hamiltonian_parameters(calc, parameters):

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,16 +34,15 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    wheel
+    packaging    
+    ruamel.yaml
     PyQt5
     h5py
-    matplotlib
+    matplotlib~=3.5.0
     numpy
-    packaging
-    pyyaml
     silx
-    wheel
     xraydb
-    Jinja2 <=3.0
 python_requires = >=3.7
 include_package_data = True
 


### PR DESCRIPTION
The PR replaces `pyyaml` with `runamel` and pins the `matplotlib` version until the next `silx` update.